### PR TITLE
Enable additional logging in non-production environments

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "babel-preset-es2015": "6.6.0",
     "babel-preset-react": "6.5.0",
     "express": "4.13.4",
+    "react-logger": "^1.1.0",
     "webpack": "1.12.14"
   },
   "engines": {

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "0.1.0",
   "description": "Placeholder",
   "dependencies": {
+    "babel-core": "^6.17.0",
     "history": "2.1.1",
     "marked": "0.3.5",
     "react": "15.0.0",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,6 @@
   "version": "0.1.0",
   "description": "Placeholder",
   "dependencies": {
-    "babel-core": "^6.17.0",
     "history": "2.1.1",
     "marked": "0.3.5",
     "react": "15.0.0",
@@ -15,6 +14,7 @@
     "superagent-promise": "1.1.0"
   },
   "devDependencies": {
+    "babel-core": "^6.17.0",
     "babel-loader": "6.2.4",
     "babel-plugin-transform-object-rest-spread": "6.8.0",
     "babel-preset-es2015": "6.6.0",

--- a/src/store.js
+++ b/src/store.js
@@ -1,9 +1,17 @@
 import { applyMiddleware, createStore } from 'redux';
+import createLogger from 'redux-logger'
 import { promiseMiddleware, localStorageMiddleware } from './middleware';
 import reducer from './reducer';
 
-const middleware = applyMiddleware(promiseMiddleware, localStorageMiddleware);
+const getMiddleware = () => {
+  if (process.env.NODE_ENV === 'production') {
+    return applyMiddleware(promiseMiddleware, localStorageMiddleware);
+  } else {
+    // Enable additional logging in non-production environments.
+    return applyMiddleware(promiseMiddleware, localStorageMiddleware, createLogger())
+  }
+}
 
-const store = createStore(reducer, middleware);
+const store = createStore(reducer, getMiddleware());
 
 export default store;


### PR DESCRIPTION
Loving this example repo, thanks for creating :bow:. I found it helpful to enable additional logging in non-production environments so that it was easier to trace the actions being dispatched. Will defer to maintainers good judgement as to whether this makes sense to merge.

ℹ️ I also added `babel-core` as a dev dependency, was giving me an error.

If anyone reading this is new to `redux-logger` the output will look like this:

![image](https://cloud.githubusercontent.com/assets/311182/19398100/9c58ae40-9210-11e6-9c21-ffcb9c7f9771.png)