### PR TITLE
Fix wrong dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "babel-preset-es2015": "6.6.0",
     "babel-preset-react": "6.5.0",
     "express": "4.13.4",
-    "react-logger": "^1.1.0",
+    "redux-logger": "^2.7.0",
     "webpack": "1.12.14"
   },
   "engines": {


### PR DESCRIPTION
The last PR #24 added the logging redux middleware, but installed `react-logging` instead of `redux-logging` for some reason.