### PR TITLE
Fix missing Link component import

### DIFF
--- a/src/components/Article/CommentContainer.js
+++ b/src/components/Article/CommentContainer.js
@@ -1,5 +1,6 @@
 import CommentInput from './CommentInput';
 import CommentList from './CommentList';
+import { Link } from 'react-router';
 import React from 'react';
 
 const CommentContainer = props => {


### PR DESCRIPTION
If user is not logged in, the component will render a couple of `Link` component, but the component is never imported.