### PR TITLE
Update the react-router to v4 smoothly

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,13 +7,15 @@
     "react-scripts": "0.9.5"
   },
   "dependencies": {
-    "history": "^4.3.0",
+    "history": "^4.6.3",
     "marked": "^0.3.6",
     "prop-types": "^15.5.10",
     "react": "^15.5.0",
     "react-dom": "^15.5.0",
     "react-redux": "^4.4.8",
-    "react-router": "^3.0.4",
+    "react-router": "^4.1.2",
+    "react-router-dom": "^4.1.2",
+    "react-router-redux": "^5.0.0-alpha.6",
     "redux": "^3.6.0",
     "redux-devtools-extension": "^2.13.2",
     "redux-logger": "^3.0.1",

--- a/src/components/App.js
+++ b/src/components/App.js
@@ -1,16 +1,27 @@
 import agent from '../agent';
 import Header from './Header';
 import React from 'react';
-import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { APP_LOAD, REDIRECT } from '../constants/actionTypes';
+import { Route, Switch } from 'react-router-dom';
+import Article from '../components/Article';
+import Editor from '../components/Editor';
+import Home from '../components/Home';
+import Login from '../components/Login';
+import Profile from '../components/Profile';
+import ProfileFavorites from '../components/ProfileFavorites';
+import Register from '../components/Register';
+import Settings from '../components/Settings';
+import { store } from '../store';
+import { push } from 'react-router-redux';
 
-const mapStateToProps = state => ({
-  appLoaded: state.common.appLoaded,
-  appName: state.common.appName,
-  currentUser: state.common.currentUser,
-  redirectTo: state.common.redirectTo
-});
+const mapStateToProps = state => {
+  return {
+    appLoaded: state.common.appLoaded,
+    appName: state.common.appName,
+    currentUser: state.common.currentUser,
+    redirectTo: state.common.redirectTo
+  }};
 
 const mapDispatchToProps = dispatch => ({
   onLoad: (payload, token) =>
@@ -22,7 +33,8 @@ const mapDispatchToProps = dispatch => ({
 class App extends React.Component {
   componentWillReceiveProps(nextProps) {
     if (nextProps.redirectTo) {
-      this.context.router.replace(nextProps.redirectTo);
+      // this.context.router.replace(nextProps.redirectTo);
+      store.dispatch(push(nextProps.redirectTo));
       this.props.onRedirect();
     }
   }
@@ -43,7 +55,17 @@ class App extends React.Component {
           <Header
             appName={this.props.appName}
             currentUser={this.props.currentUser} />
-          {this.props.children}
+            <Switch>
+            <Route exact path="/" component={Home}/>
+            <Route path="/login" component={Login} />
+            <Route path="/register" component={Register} />
+            <Route path="/editor/:slug" component={Editor} />
+            <Route path="/editor" component={Editor} />
+            <Route path="/article/:id" component={Article} />
+            <Route path="/settings" component={Settings} />
+            <Route path="/@:username/favorites" component={ProfileFavorites} />
+            <Route path="/@:username" component={Profile} />
+            </Switch>
         </div>
       );
     }
@@ -57,8 +79,8 @@ class App extends React.Component {
   }
 }
 
-App.contextTypes = {
-  router: PropTypes.object.isRequired
-};
+// App.contextTypes = {
+//   router: PropTypes.object.isRequired
+// };
 
 export default connect(mapStateToProps, mapDispatchToProps)(App);

--- a/src/components/Article/ArticleActions.js
+++ b/src/components/Article/ArticleActions.js
@@ -1,4 +1,4 @@
-import { Link } from 'react-router';
+import { Link } from 'react-router-dom';
 import React from 'react';
 import agent from '../../agent';
 import { connect } from 'react-redux';

--- a/src/components/Article/ArticleMeta.js
+++ b/src/components/Article/ArticleMeta.js
@@ -1,17 +1,17 @@
 import ArticleActions from './ArticleActions';
-import { Link } from 'react-router';
+import { Link } from 'react-router-dom';
 import React from 'react';
 
 const ArticleMeta = props => {
   const article = props.article;
   return (
     <div className="article-meta">
-      <Link to={`@${article.author.username}`}>
+      <Link to={`/@${article.author.username}`}>
         <img src={article.author.image} alt={article.author.username} />
       </Link>
 
       <div className="info">
-        <Link to={`@${article.author.username}`} className="author">
+        <Link to={`/@${article.author.username}`} className="author">
           {article.author.username}
         </Link>
         <span className="date">

--- a/src/components/Article/Comment.js
+++ b/src/components/Article/Comment.js
@@ -1,5 +1,5 @@
 import DeleteButton from './DeleteButton';
-import { Link } from 'react-router';
+import { Link } from 'react-router-dom';
 import React from 'react';
 
 const Comment = props => {
@@ -13,13 +13,13 @@ const Comment = props => {
       </div>
       <div className="card-footer">
         <Link
-          to={`@${comment.author.username}`}
+          to={`/@${comment.author.username}`}
           className="comment-author">
           <img src={comment.author.image} className="comment-author-img" alt={comment.author.username} />
         </Link>
         &nbsp;
         <Link
-          to={`@${comment.author.username}`}
+          to={`/@${comment.author.username}`}
           className="comment-author">
           {comment.author.username}
         </Link>

--- a/src/components/Article/CommentContainer.js
+++ b/src/components/Article/CommentContainer.js
@@ -1,6 +1,6 @@
 import CommentInput from './CommentInput';
 import CommentList from './CommentList';
-import { Link } from 'react-router';
+import { Link } from 'react-router-dom';
 import React from 'react';
 
 const CommentContainer = props => {
@@ -22,9 +22,9 @@ const CommentContainer = props => {
     return (
       <div className="col-xs-12 col-md-8 offset-md-2">
         <p>
-          <Link to="login">Sign in</Link>
+          <Link to="/login">Sign in</Link>
           &nbsp;or&nbsp;
-          <Link to="register">sign up</Link>
+          <Link to="/register">sign up</Link>
           &nbsp;to add comments on this article.
         </p>
 

--- a/src/components/Article/index.js
+++ b/src/components/Article/index.js
@@ -21,8 +21,8 @@ const mapDispatchToProps = dispatch => ({
 class Article extends React.Component {
   componentWillMount() {
     this.props.onLoad(Promise.all([
-      agent.Articles.get(this.props.params.id),
-      agent.Comments.forArticle(this.props.params.id)
+      agent.Articles.get(this.props.match.params.id),
+      agent.Comments.forArticle(this.props.match.params.id)
     ]));
   }
 
@@ -85,7 +85,7 @@ class Article extends React.Component {
             <CommentContainer
               comments={this.props.comments || []}
               errors={this.props.commentErrors}
-              slug={this.props.params.id}
+              slug={this.props.match.params.id}
               currentUser={this.props.currentUser} />
           </div>
         </div>

--- a/src/components/ArticlePreview.js
+++ b/src/components/ArticlePreview.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Link } from 'react-router';
+import { Link } from 'react-router-dom';
 import agent from '../agent';
 import { connect } from 'react-redux';
 import { ARTICLE_FAVORITED, ARTICLE_UNFAVORITED } from '../constants/actionTypes';
@@ -36,12 +36,12 @@ const ArticlePreview = props => {
   return (
     <div className="article-preview">
       <div className="article-meta">
-        <Link to={`@${article.author.username}`}>
+        <Link to={`/@${article.author.username}`}>
           <img src={article.author.image} alt={article.author.username} />
         </Link>
 
         <div className="info">
-          <Link className="author" to={`@${article.author.username}`}>
+          <Link className="author" to={`/@${article.author.username}`}>
             {article.author.username}
           </Link>
           <span className="date">
@@ -56,7 +56,7 @@ const ArticlePreview = props => {
         </div>
       </div>
 
-      <Link to={`article/${article.slug}`} className="preview-link">
+      <Link to={`/article/${article.slug}`} className="preview-link">
         <h1>{article.title}</h1>
         <p>{article.description}</p>
         <span>Read more...</span>

--- a/src/components/Editor.js
+++ b/src/components/Editor.js
@@ -71,18 +71,18 @@ class Editor extends React.Component {
   }
 
   componentWillReceiveProps(nextProps) {
-    if (this.props.params.slug !== nextProps.params.slug) {
-      if (nextProps.params.slug) {
+    if (this.props.match.params.slug !== nextProps.match.params.slug) {
+      if (nextProps.match.params.slug) {
         this.props.onUnload();
-        return this.props.onLoad(agent.Articles.get(this.props.params.slug));
+        return this.props.onLoad(agent.Articles.get(this.props.match.params.slug));
       }
       this.props.onLoad(null);
     }
   }
 
   componentWillMount() {
-    if (this.props.params.slug) {
-      return this.props.onLoad(agent.Articles.get(this.props.params.slug));
+    if (this.props.match.params.slug) {
+      return this.props.onLoad(agent.Articles.get(this.props.match.params.slug));
     }
     this.props.onLoad(null);
   }

--- a/src/components/Header.js
+++ b/src/components/Header.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Link } from 'react-router';
+import { Link } from 'react-router-dom';
 
 const LoggedOutView = props => {
   if (!props.currentUser) {
@@ -13,13 +13,13 @@ const LoggedOutView = props => {
         </li>
 
         <li className="nav-item">
-          <Link to="login" className="nav-link">
+          <Link to="/login" className="nav-link">
             Sign in
           </Link>
         </li>
 
         <li className="nav-item">
-          <Link to="register" className="nav-link">
+          <Link to="/register" className="nav-link">
             Sign up
           </Link>
         </li>
@@ -42,20 +42,20 @@ const LoggedInView = props => {
         </li>
 
         <li className="nav-item">
-          <Link to="editor" className="nav-link">
+          <Link to="/editor" className="nav-link">
             <i className="ion-compose"></i>&nbsp;New Post
           </Link>
         </li>
 
         <li className="nav-item">
-          <Link to="settings" className="nav-link">
+          <Link to="/settings" className="nav-link">
             <i className="ion-gear-a"></i>&nbsp;Settings
           </Link>
         </li>
 
         <li className="nav-item">
           <Link
-            to={`@${props.currentUser.username}`}
+            to={`/@${props.currentUser.username}`}
             className="nav-link">
             <img src={props.currentUser.image} className="user-pic" alt={props.currentUser.username} />
             {props.currentUser.username}

--- a/src/components/Login.js
+++ b/src/components/Login.js
@@ -48,7 +48,7 @@ class Login extends React.Component {
             <div className="col-md-6 offset-md-3 col-xs-12">
               <h1 className="text-xs-center">Sign In</h1>
               <p className="text-xs-center">
-                <Link to="register">
+                <Link to="/register">
                   Need an account?
                 </Link>
               </p>

--- a/src/components/Profile.js
+++ b/src/components/Profile.js
@@ -1,6 +1,6 @@
 import ArticleList from './ArticleList';
 import React from 'react';
-import { Link } from 'react-router';
+import { Link } from 'react-router-dom';
 import agent from '../agent';
 import { connect } from 'react-redux';
 import {
@@ -14,7 +14,7 @@ const EditProfileSettings = props => {
   if (props.isUser) {
     return (
       <Link
-        to="settings"
+        to="/settings"
         className="btn btn-sm btn-outline-secondary action-btn">
         <i className="ion-gear-a"></i> Edit Profile Settings
       </Link>
@@ -77,8 +77,8 @@ const mapDispatchToProps = dispatch => ({
 class Profile extends React.Component {
   componentWillMount() {
     this.props.onLoad(Promise.all([
-      agent.Profile.get(this.props.params.username),
-      agent.Articles.byAuthor(this.props.params.username)
+      agent.Profile.get(this.props.match.params.username),
+      agent.Articles.byAuthor(this.props.match.params.username)
     ]));
   }
 
@@ -92,7 +92,7 @@ class Profile extends React.Component {
         <li className="nav-item">
           <Link
             className="nav-link active"
-            to={`@${this.props.profile.username}`}>
+            to={`/@${this.props.profile.username}`}>
             My Articles
           </Link>
         </li>
@@ -100,7 +100,7 @@ class Profile extends React.Component {
         <li className="nav-item">
           <Link
             className="nav-link"
-            to={`@${this.props.profile.username}/favorites`}>
+            to={`/@${this.props.profile.username}/favorites`}>
             Favorited Articles
           </Link>
         </li>

--- a/src/components/ProfileFavorites.js
+++ b/src/components/ProfileFavorites.js
@@ -1,6 +1,6 @@
 import { Profile, mapStateToProps } from './Profile';
 import React from 'react';
-import { Link } from 'react-router';
+import { Link } from 'react-router-dom';
 import agent from '../agent';
 import { connect } from 'react-redux';
 import {
@@ -17,9 +17,9 @@ const mapDispatchToProps = dispatch => ({
 
 class ProfileFavorites extends Profile {
   componentWillMount() {
-    this.props.onLoad(page => agent.Articles.favoritedBy(this.props.params.username, page), Promise.all([
-      agent.Profile.get(this.props.params.username),
-      agent.Articles.favoritedBy(this.props.params.username)
+    this.props.onLoad(page => agent.Articles.favoritedBy(this.props.match.params.username, page), Promise.all([
+      agent.Profile.get(this.props.match.params.username),
+      agent.Articles.favoritedBy(this.props.match.params.username)
     ]));
   }
 
@@ -33,7 +33,7 @@ class ProfileFavorites extends Profile {
         <li className="nav-item">
           <Link
             className="nav-link"
-            to={`@${this.props.profile.username}`}>
+            to={`/@${this.props.profile.username}`}>
             My Articles
           </Link>
         </li>
@@ -41,7 +41,7 @@ class ProfileFavorites extends Profile {
         <li className="nav-item">
           <Link
             className="nav-link active"
-            to={`@${this.props.profile.username}/favorites`}>
+            to={`/@${this.props.profile.username}/favorites`}>
             Favorited Articles
           </Link>
         </li>

--- a/src/components/Register.js
+++ b/src/components/Register.js
@@ -55,7 +55,7 @@ class Register extends React.Component {
             <div className="col-md-6 offset-md-3 col-xs-12">
               <h1 className="text-xs-center">Sign Up</h1>
               <p className="text-xs-center">
-                <Link to="login">
+                <Link to="/login">
                   Have an account?
                 </Link>
               </p>

--- a/src/index.js
+++ b/src/index.js
@@ -1,33 +1,20 @@
 import ReactDOM from 'react-dom';
 import { Provider } from 'react-redux';
 import React from 'react';
-import { Router, Route, IndexRoute, hashHistory } from 'react-router';
-import store from './store';
+import { store, history} from './store';
+
+import { Route, Switch } from 'react-router-dom';
+import { ConnectedRouter } from 'react-router-redux';
 
 import App from './components/App';
-import Article from './components/Article';
-import Editor from './components/Editor';
-import Home from './components/Home';
-import Login from './components/Login';
-import Profile from './components/Profile';
-import ProfileFavorites from './components/ProfileFavorites';
-import Register from './components/Register';
-import Settings from './components/Settings';
 
 ReactDOM.render((
   <Provider store={store}>
-    <Router history={hashHistory}>
-      <Route path="/" component={App}>
-        <IndexRoute component={Home} />
-        <Route path="login" component={Login} />
-        <Route path="register" component={Register} />
-        <Route path="editor" component={Editor} />
-        <Route path="editor/:slug" component={Editor} />
-        <Route path="article/:id" component={Article} />
-        <Route path="settings" component={Settings} />
-        <Route path="@:username" component={Profile} />
-        <Route path="@:username/favorites" component={ProfileFavorites} />
-      </Route>
-    </Router>
+    <ConnectedRouter history={history}>
+      <Switch>
+        <Route path="/" component={App} />
+      </Switch>
+    </ConnectedRouter>
   </Provider>
+
 ), document.getElementById('root'));

--- a/src/reducer.js
+++ b/src/reducer.js
@@ -7,6 +7,7 @@ import editor from './reducers/editor';
 import home from './reducers/home';
 import profile from './reducers/profile';
 import settings from './reducers/settings';
+import { routerReducer } from 'react-router-redux';
 
 export default combineReducers({
   article,
@@ -16,5 +17,6 @@ export default combineReducers({
   editor,
   home,
   profile,
-  settings
+  settings,
+  router: routerReducer
 });

--- a/src/reducers/common.js
+++ b/src/reducers/common.js
@@ -37,7 +37,7 @@ export default (state = defaultState, action) => {
     case LOGOUT:
       return { ...state, redirectTo: '/', token: null, currentUser: null };
     case ARTICLE_SUBMITTED:
-      const redirectUrl = `article/${action.payload.article.slug}`;
+      const redirectUrl = `/article/${action.payload.article.slug}`;
       return { ...state, redirectTo: redirectUrl };
     case SETTINGS_SAVED:
       return {

--- a/src/store.js
+++ b/src/store.js
@@ -4,15 +4,22 @@ import { composeWithDevTools } from 'redux-devtools-extension/developmentOnly';
 import { promiseMiddleware, localStorageMiddleware } from './middleware';
 import reducer from './reducer';
 
+import { routerMiddleware } from 'react-router-redux'
+import createHistory from 'history/createBrowserHistory';
+
+export const history = createHistory();
+
+// Build the middleware for intercepting and dispatching navigation actions
+const myRouterMiddleware = routerMiddleware(history);
+
 const getMiddleware = () => {
   if (process.env.NODE_ENV === 'production') {
-    return applyMiddleware(promiseMiddleware, localStorageMiddleware);
+    return applyMiddleware(myRouterMiddleware, promiseMiddleware, localStorageMiddleware);
   } else {
     // Enable additional logging in non-production environments.
-    return applyMiddleware(promiseMiddleware, localStorageMiddleware, createLogger())
+    return applyMiddleware(myRouterMiddleware, promiseMiddleware, localStorageMiddleware, createLogger())
   }
-}
+};
 
-const store = createStore(reducer, composeWithDevTools(getMiddleware()))
-
-export default store;
+export const store = createStore(
+  reducer, composeWithDevTools(getMiddleware()));


### PR DESCRIPTION
Update the react-router to v4
- use react-router-redux to connect react-router and redux
- change path patterns to match the urls
- change Link to string to start with "/"
- change props.params to props.match.params
- change redirect logic to using 'push' in 'react-router-redux'
- add routerReducer to reducers

@EricSimons  Could you help to accept this PR?
I think many people need this, hope it could be helpful.